### PR TITLE
Fix bug: ValueError: Dimension 0 in both shapes must be equal, but are 256 and 257 for 'lambda_1/concat_2' (op: 'ConcatV2') with input shapes: [?,32,128,256], [?,32,128,257], [] and with computed input tensors: input[2] = <2>.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project reimplements the GCNetwork developed by Kendal, et al(2017). Curren
   
   data : path for training data
   
-  -mpath : pretrained model path. Provided when mode is 0 for 1.
+  -wpath : pretrained model path. Provided when mode is 0 for 1.
   
   -bs : batch_size. default = 1
   
@@ -26,7 +26,7 @@ This project reimplements the GCNetwork developed by Kendal, et al(2017). Curren
   
   -ep : epochs. default = 10
   
-  -mspath : model_save_path. used when mode is 1 or 2
+  -wspath : model_save_path. used when mode is 1 or 2
   
   -lspath : log_save_path. used when mode is 1 or 2. This is the log file used in Tensorboard.
   
@@ -35,5 +35,7 @@ This project reimplements the GCNetwork developed by Kendal, et al(2017). Curren
   -pspath : file for saving predicted result. Used when mode is 0.
 
   ex: srun --pty python code/main.py 2 data/mb_data/mb_train.npz \\-mspath model/mb_model/mbModel.h5 -lspath log/mb_log/log -vdata data/mb_data/mb_val.npz --epochs 
+  
+  Or simply: python code/main.py -mode 2 -data data/mb_data/mb_train.npz -wspath model/mb_model/mbModel.h5 -lspath log/mb_log/log -vdata data/mb_data/mb_val.npz
 
 #### Reference: Kendall, Alex, et al. "End-to-End Learning of Geometry and Context for Deep Stereo Regression." arXiv preprint arXiv:1703.04309 (2017).

--- a/code/gcnetwork.py
+++ b/code/gcnetwork.py
@@ -64,7 +64,7 @@ def _getCostVolume_(inputs, d):
         b,f,h,w = lf.get_shape().as_list()
         rf = states[0]
         rfs = rf[:, :, :, 0:]
-        disp_rfs = K.spatial_2d_padding(rfs, padding = ((0, 0), (1, 0)), data_format = 'channels_first')
+        disp_rfs = K.spatial_2d_padding(rfs, padding = ((0, 0), (0, 0)), data_format = 'channels_first')
         concat = K.concatenate([lf, rf], axis = 2)
         output = K.reshape(concat, (-1, 2*f, h, w))
         return output, [disp_rfs]


### PR DESCRIPTION
The original version has a bug. I fix the error of `gcnetwork.py`.
```
jack@jack:~/Applications/GCNetwork$ python code/main.py -mode 2 -data data/mb_data/mb_train.npz -wspath model/mb_model/mbModel.h5 -lspath log/mb_log/log -vdata data/mb_data/mb_val.npz
Using TensorFlow backend.
Reading all necessary libraries
model will be saved as model/mb_model/mbModel.h5
Traceback (most recent call last):
  File "code/main.py", line 48, in <module>
    trainModel(train_data = [limages, rimages, gtimages], callbacks = callbacks, weight_path = weight_path, lr = args.learning_rate, epochs = args.epochs, batch_size = args.batch_size, val_data = val_data)
  File "/home/jack/Applications/GCNetwork/code/network_utils.py", line 24, in trainModel
    model = createGCNetwork(left_img, right_img)
  File "/home/jack/Applications/GCNetwork/code/gcnetwork.py", line 154, in createGCNetwork
    cv = Lambda(_getCostVolume_, arguments = {'d':d/2})([left_feature, right_feature])
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/keras/engine/topology.py", line 596, in __call__
    output = self.call(inputs, **kwargs)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/keras/layers/core.py", line 647, in call
    return self.function(inputs, **arguments)
  File "/home/jack/Applications/GCNetwork/code/gcnetwork.py", line 77, in _getCostVolume_
    l,o,n = K.rnn(featureConcat, inputs = left_feature, initial_states = [right_feature], unroll = True)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/keras/backend/tensorflow_backend.py", line 2443, in rnn
    output, states = step_function(inp, states + constants)
  File "/home/jack/Applications/GCNetwork/code/gcnetwork.py", line 70, in featureConcat
    concat = K.concatenate([lf, rf], axis = 2)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/keras/backend/tensorflow_backend.py", line 1723, in concatenate
    return tf.concat([to_dense(x) for x in tensors], axis)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/ops/array_ops.py", line 1048, in concat
    name=name)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/ops/gen_array_ops.py", line 495, in _concat_v2
    name=name)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/framework/op_def_library.py", line 767, in apply_op
    op_def=op_def)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 2508, in create_op
    set_shapes_for_outputs(ret)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1873, in set_shapes_for_outputs
    shapes = shape_func(op)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1823, in call_with_requiring
    return call_cpp_shape_fn(op, require_shape_fn=True)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/framework/common_shapes.py", line 610, in call_cpp_shape_fn
    debug_python_shape_fn, require_shape_fn)
  File "/home/jack/python3/A3C-PyTorch/local/lib/python2.7/site-packages/tensorflow/python/framework/common_shapes.py", line 676, in _call_cpp_shape_fn_impl
    raise ValueError(err.message)
ValueError: Dimension 0 in both shapes must be equal, but are 256 and 257 for 'lambda_1/concat_2' (op: 'ConcatV2') with input shapes: [?,32,128,256], [?,32,128,257], [] and with computed input tensors: input[2] = <2>.

```